### PR TITLE
Expired auth token should be in the past

### DIFF
--- a/source/middleware/auth.js
+++ b/source/middleware/auth.js
@@ -39,7 +39,7 @@ function validateToken (req, res, next) {
 		}
 
 		var currentTimespamp = moment(), recievedTimespamp = moment(+timespamp);
-		if (recievedTimespamp.diff(currentTimespamp, 'minutes') > TOKEN_TTL_MINUTES) {
+		if (currentTimespamp.diff(recievedTimespamp, 'minutes') > TOKEN_TTL_MINUTES) {
 			return false;
 		}
 

--- a/test/api/auth.specs.js
+++ b/test/api/auth.specs.js
@@ -250,7 +250,7 @@ describe('/api/auth.js', function () {
 		describe('expired token', function () {
 			beforeEach(function () {
 				var key = '95810db3f765480999a8d5089b0815bd4b55e831';
-				var username = 'user', timespamp = moment().add('hours', 1).add('minutes', 2).valueOf();
+				var username = 'user', timespamp = moment().subtract('hours', 1).subtract('minutes', 2).valueOf();
 				var message = username + ';' + timespamp;
 				var hmac = crypto.createHmac('sha1', key).update(message).digest('hex');
 


### PR DESCRIPTION
Hi, 
I found a issue with an expired token that never would be invalidated.

``` javascript
var TOKEN_TTL_MINUTES = 60;
// differenceInMinutes will result in a negative value, for example -61
var differenceInMinutes = recievedTimespamp.diff(currentTimespamp, 'minutes'); // -61
if (-61 > TOKEN_TTL_MINUTES) {
    return false; // this will never be reached with an expired token
}
```

[see momentjs, a.diff(b, 'minutes)](http://momentjs.com/docs/#/displaying/difference/)
