### PR TITLE
Change express dependency to ~3.4.8 to target a valid install

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "node runMocha"
   },
   "dependencies": {
-    "express": "3.0.0rc4",
+    "express": "~3.4.8",
     "ejs": "*",
     "underscore": "~1.4.4",
     "moment": "~2.0.0",


### PR DESCRIPTION
Hi, 

`npm install` gives the following error:

``` sh
$ npm install
npm ERR! Error: No compatible version found: express@'3.0.0rc4'
npm ERR! Valid install targets:
npm ERR! ["0.14.0","0.14.1","1.0.0","1.0.1","1.0.2","1.0.3","1.0.4","1.0.5","1.0.6","1.0.7","1.0.8","2.0.0","2.1.0","2.1.1","2.2.0","2.2.1","2.2.2","2.3.0","2.3.1","2.3.2","2.3.3","2.3.4","2.3.5","2.3.6","2.3.7","2.3.8","2.3.9","2.3.10","2.3.11","2.3.12","2.4.0","2.4.1","2.4.2","2.4.3","2.4.4","2.4.5","2.4.6","2.4.7","2.5.0","2.5.1","2.5.2","2.5.3","2.5.4","2.5.5","2.5.6","2.5.7","2.5.8","2.5.9","2.5.10","2.5.11","3.0.0","3.0.1","3.0.2","3.0.3","3.0.4","3.0.5","3.0.6","3.1.0","3.1.1","3.1.2","3.2.0","3.2.1","3.2.2","3.2.3","3.2.4","3.2.5","3.2.6","3.3.0","3.3.1","3.3.2","3.3.3","3.3.4","3.3.5","3.3.6","1.0.0-beta","1.0.0-beta2","1.0.0-rc","1.0.0-rc2","1.0.0-rc3","1.0.0-rc4","2.0.0-beta","2.0.0-beta2","2.0.0-beta3","2.0.0-rc","2.0.0-rc2","2.0.0-rc3","3.0.0-alpha1","3.0.0-alpha2","3.0.0-alpha3","3.0.0-alpha4","3.0.0-alpha5","3.0.0-beta1","3.0.0-beta2","3.0.0-beta3","3.0.0-beta4","3.0.0-beta6","3.0.0-beta7","3.0.0-rc1","3.0.0-rc2","3.0.0-rc3","3.0.0-rc4","3.0.0-rc5","3.3.7","3.3.8","3.4.0","3.4.1","3.4.2","3.4.3","3.4.4","3.4.5","3.4.6","3.4.7","3.4.8"]
npm ERR!     at installTargetsError (/usr/share/npm/lib/cache.js:685:10)
```

Changing expressing version to `~3.4.8` fixes this issue for me. 
